### PR TITLE
Updated cp4s.

### DIFF
--- a/terraform/cp4s/main.tf
+++ b/terraform/cp4s/main.tf
@@ -61,11 +61,8 @@ module "cp4s" {
   // source = "../../../../ibm-hcbt/terraform-ibm-cloud-pak/cp4data"
   source = "github.com/ibm-hcbt/terraform-ibm-cloud-pak.git//modules/cp4s?ref=terraform-0.13"
   enable = true
-  force  = true
-
 
   // ROKS cluster parameters:
-  openshift_version   = local.roks_version
   cluster_config_path = data.ibm_container_cluster_config.cluster_config.config_file_path
 
   // Entitled Registry parameters:

--- a/terraform/cp4s/variables.tf
+++ b/terraform/cp4s/variables.tf
@@ -80,7 +80,6 @@ variable "entitled_registry_user_email" {
 // Local Variables and constants
 locals {
   workers_count              = [5]
-  roks_version               = "4.7"
   kubeconfig_dir             = "./.kube/config"
   entitled_registry_key_file = "./entitlement.key"
 }


### PR DESCRIPTION
Removed unneeded variables from CP4S based on the following from the tekton pipeline:

```
2022/01/28 20:12:14 Terraform plan | Error: Unsupported argument
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan |   on main.tf line 64, in module "cp4s":
 2022/01/28 20:12:14 Terraform plan |   64:   force  = true
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan | An argument named "force" is not expected here.
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan | Error: Unsupported argument
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan |   on main.tf line 68, in module "cp4s":
 2022/01/28 20:12:14 Terraform plan |   68:   openshift_version   = local.roks_version
 2022/01/28 20:12:14 Terraform plan | 
 2022/01/28 20:12:14 Terraform plan | An argument named "openshift_version" is not expected here.
```